### PR TITLE
cleaning up cmake linking against gnuradio-filter and gnuradio-fft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,8 @@ set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
 ########################################################################
 # Find gnuradio build dependencies
 ########################################################################
-find_package(GnuradioRuntime)
+set(GR_REQUIRED_COMPONENTS RUNTIME FILTER FFT)
+find_package(Gnuradio)
 find_package(CppUnit)
 
 if(NOT GNURADIO_RUNTIME_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,10 +34,12 @@ list(APPEND gr_ieee802_11_sources
 list(APPEND gr_ieee802_11_libs
     ${Boost_LIBRARIES}
     ${GNURADIO_RUNTIME_LIBRARIES}
+    ${GNURADIO_FFT_LIBRARIES} 
+    ${GNURADIO_FILTER_LIBRARIES}
 )
 
 add_library(gnuradio-ieee802_11 SHARED ${gr_ieee802_11_sources})
-target_link_libraries(gnuradio-ieee802_11 ${gr_ieee802_11_libs} itpp gnuradio-fft gnuradio-filter)
+target_link_libraries(gnuradio-ieee802_11 ${gr_ieee802_11_libs} itpp)
 set_target_properties(gnuradio-ieee802_11 PROPERTIES DEFINE_SYMBOL "gnuradio_ieee802_11_EXPORTS")
 
 ########################################################################


### PR DESCRIPTION
using cmake to find gnuradio-filter and gnuradio-fft, required for some build environments
