### PR TITLE
Fix build in some environments

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -19,7 +19,7 @@
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)
-find_package(PythonLibs)
+find_package(PythonLibs 2)
 if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
     return()
 endif()


### PR DESCRIPTION
Adding find_package(PythonLibs 2) to make sure that it doesn't use
version 3 of PythonLibs.