### PR TITLE
Add parameter to ofdm_mac block to strip MAC header from incoming MPDUs

### DIFF
--- a/grc/ieee802_11_ofdm_mac.xml
+++ b/grc/ieee802_11_ofdm_mac.xml
@@ -5,7 +5,7 @@
 	<key>ieee802_11_ofdm_mac</key>
 	<category>IEEE802.11</category>
 	<import>import ieee802_11</import>
-	<make>ieee802_11.ofdm_mac($src_mac, $dst_mac, $bss_mac)</make>
+	<make>ieee802_11.ofdm_mac($src_mac, $dst_mac, $bss_mac, $strip_header)</make>
 
 	<param>
 		<name>SRC MAC</name>
@@ -27,6 +27,22 @@
 		<value>[0xff, 0xff, 0xff, 0xff, 0xff, 0xff]</value>
 		<type>int_vector</type>
 	</param>
+
+    <param>
+      <name>Strip header</name>
+      <key>strip_header</key>
+      <value>False</value>
+      <type>bool</type>
+
+      <option>
+        <name>Yes</name>
+        <key>True</key>
+      </option>
+      <option>
+        <name>No</name>
+        <key>False</key>
+      </option>
+    </param>  
 
 	<check>len($src_mac) == 6</check>
 	<check>len($dst_mac) == 6</check>

--- a/include/ieee802-11/ofdm_mac.h
+++ b/include/ieee802-11/ofdm_mac.h
@@ -30,7 +30,8 @@ public:
 	typedef boost::shared_ptr<ofdm_mac> sptr;
 	static sptr make(std::vector<uint8_t> src_mac,
 			std::vector<uint8_t> dst_mac,
-			std::vector<uint8_t> bss_mac);
+			std::vector<uint8_t> bss_mac,
+			bool strip_header);
 };
 
 }  // namespace ieee802_11

--- a/lib/ether_encap_impl.cc
+++ b/lib/ether_encap_impl.cc
@@ -60,7 +60,7 @@ ether_encap_impl::from_wifi(pmt::pmt_t msg) {
 		return;
 	}
 
-	// this is more than neeed
+	// this is more than needed
 	char *buf = static_cast<char*>(std::malloc(data_len + sizeof(ethernet_header)));
 	ethernet_header *ehdr = reinterpret_cast<ethernet_header*>(buf);
 

--- a/lib/ofdm_decode_mac.cc
+++ b/lib/ofdm_decode_mac.cc
@@ -309,9 +309,9 @@ private:
 	char out_bits[40000];
 	char out_bytes[40000];
 	bvec decoded_bits;
-	bool   d_debug;
-	bool   d_log;
 
+	bool d_debug;
+	bool d_log;
 	tx_param tx;
 	ofdm_param ofdm;
 	int copied;


### PR DESCRIPTION
Hi Basti,
this patch allows to remove the MAC header from an incoming MPDU, if desired. The default option is to leave the MPDU as it is, which is what we have right now.
However, certain blocks may not be interested in the MAC header of incoming frames, so the block should offer an option to remove it.

The patch also includes two whitespace and typo fixes, the two you couldn't merge before I hope.

Cheers
Andre