### PR TITLE
bugfix: link between EQ parameters and simulation parameters

### DIFF
--- a/examples/wifi_rx.grc
+++ b/examples/wifi_rx.grc
@@ -1064,6 +1064,10 @@
       <value>chan_est</value>
     </param>
     <param>
+      <key>bw</key>
+      <value>samp_rate</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -1082,6 +1086,10 @@
     <param>
       <key>_enabled</key>
       <value>True</value>
+    </param>
+    <param>
+      <key>freq</key>
+      <value>freq</value>
     </param>
     <param>
       <key>_coordinate</key>


### PR DESCRIPTION
The EQ parameters (bw, freq) should be updated from simulation
parameters, instead of using constants (10e6, 5.8G). After this modification, 
the equalizer parameters are automatically updated when the parameters 
are changed in the GUI.

Signed-off-by: Jonathan Brucker <jonathan.brucke@gmail.com>