### PR TITLE
Add nomfreq, freqofs, dlt to PDU metadata

### DIFF
--- a/lib/frame_equalizer_impl.h
+++ b/lib/frame_equalizer_impl.h
@@ -59,8 +59,9 @@ private:
 	viterbi_decoder d_decoder;
 
 	// freq offset
-	double d_freq;
-	double d_bw;
+	double d_freq;  // Hz
+	double d_freq_offset_from_synclong;  // Hz, estimation from "sync_long" block
+	double d_bw;  // Hz
 	double d_er;
 	double d_epsilon0;
 	gr_complex d_prev_pilots[4];


### PR DESCRIPTION
Add Nominal Frequency, Carrier Frequency Offset and Data Link Type (DLT)
tags to PDU.

Signed-off-by: Jonathan Brucker jonathan.brucke@gmail.com