### PR TITLE
Fix doxygen documentation build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ if(NOT SWIG_FOUND)
     message(FATAL_ERROR "SWIG required to compile gr-ieee802-11")
 endif()
 
+find_package(Doxygen)
 ########################################################################
 # On Apple only, set install name and use rpath correctly, if not already set
 ########################################################################


### PR DESCRIPTION
Swig (which uses doxygen) is included before the docs,
so the doxygen is not initialized