### PR TITLE
Port to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ ENDIF()
 ########################################################################
 # Install directories
 ########################################################################
-find_package(Gnuradio "3.8" REQUIRED COMPONENTS filter fft digital analog blocks)
+find_package(Gnuradio "3.9" REQUIRED COMPONENTS filter fft digital analog blocks)
 include(GrVersion)
 
 include(GrPlatform) #define LIB_SUFFIX


### PR DESCRIPTION
This tracks the change to the version of the master branch of gnuradio: commit https://github.com/gnuradio/gnuradio/commit/f1475ce5eea60d4780621b5f62b8c7a226cd29a9 changes it to 3.9.