### PR TITLE
expose CSI-values and message received.

### DIFF
--- a/examples/wifi_rx.grc
+++ b/examples/wifi_rx.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.8.git'?>
+<?grc format='1' created='3.7.14'?>
 <flow_graph>
   <timestamp>Fri Jul 18 10:38:16 2014</timestamp>
   <block>
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -595,6 +603,49 @@
     </param>
   </block>
   <block>
+    <key>blocks_complex_to_float</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(784, 760)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_complex_to_float_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>52</value>
+    </param>
+  </block>
+  <block>
     <key>blocks_complex_to_mag</key>
     <param>
       <key>alias</key>
@@ -900,7 +951,7 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>False</value>
+      <value>1</value>
     </param>
     <param>
       <key>file</key>
@@ -908,7 +959,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(768, 908)</value>
+      <value>(864, 1028)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1002,7 +1053,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(584, 836)</value>
+      <value>(424, 836)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1163,11 +1214,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>False</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(952, 916)</value>
+      <value>(1064, 1036)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1226,7 +1277,7 @@
     </param>
     <param>
       <key>log</key>
-      <value>True</value>
+      <value>False</value>
     </param>
     <param>
       <key>maxoutbuf</key>
@@ -1238,14 +1289,14 @@
     </param>
   </block>
   <block>
-    <key>ieee802_11_frame_equalizer</key>
+    <key>ieee802_11_frame_equalizer_csi</key>
     <param>
       <key>algo</key>
-      <value>chan_est</value>
+      <value>ieee802_11.LS</value>
     </param>
     <param>
       <key>bw</key>
-      <value>samp_rate</value>
+      <value>10e6</value>
     </param>
     <param>
       <key>alias</key>
@@ -1269,11 +1320,11 @@
     </param>
     <param>
       <key>freq</key>
-      <value>freq</value>
+      <value>5.89e9</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(432, 672)</value>
+      <value>(440, 676)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1281,7 +1332,7 @@
     </param>
     <param>
       <key>id</key>
-      <value>ieee802_11_frame_equalizer_0</value>
+      <value>ieee802_11_frame_equalizer_csi_0</value>
     </param>
     <param>
       <key>log</key>
@@ -1414,7 +1465,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(984, 804)</value>
+      <value>(1096, 768)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1571,7 +1622,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 828)</value>
+      <value>(152, 828)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -2205,6 +2256,10 @@
       <value>samp_rate</value>
     </param>
     <param>
+      <key>stemplot</key>
+      <value>False</value>
+    </param>
+    <param>
       <key>tr_chan</key>
       <value>0</value>
     </param>
@@ -2254,6 +2309,277 @@
     </param>
   </block>
   <block>
+    <key>qtgui_vector_sink_f</key>
+    <param>
+      <key>autoscale</key>
+      <value>False</value>
+    </param>
+    <param>
+      <key>average</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(784, 828)</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>grid</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>qtgui_vector_sink_f_0_0</value>
+    </param>
+    <param>
+      <key>alpha1</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color1</key>
+      <value>"blue"</value>
+    </param>
+    <param>
+      <key>label1</key>
+      <value>Re</value>
+    </param>
+    <param>
+      <key>width1</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha10</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color10</key>
+      <value>"dark blue"</value>
+    </param>
+    <param>
+      <key>label10</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width10</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha2</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color2</key>
+      <value>"red"</value>
+    </param>
+    <param>
+      <key>label2</key>
+      <value>Im</value>
+    </param>
+    <param>
+      <key>width2</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha3</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color3</key>
+      <value>"green"</value>
+    </param>
+    <param>
+      <key>label3</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width3</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha4</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color4</key>
+      <value>"black"</value>
+    </param>
+    <param>
+      <key>label4</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width4</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha5</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color5</key>
+      <value>"cyan"</value>
+    </param>
+    <param>
+      <key>label5</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width5</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha6</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color6</key>
+      <value>"magenta"</value>
+    </param>
+    <param>
+      <key>label6</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width6</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha7</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color7</key>
+      <value>"yellow"</value>
+    </param>
+    <param>
+      <key>label7</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width7</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha8</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color8</key>
+      <value>"dark red"</value>
+    </param>
+    <param>
+      <key>label8</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width8</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>alpha9</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>color9</key>
+      <value>"dark green"</value>
+    </param>
+    <param>
+      <key>label9</key>
+      <value></value>
+    </param>
+    <param>
+      <key>width9</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>name</key>
+      <value>""</value>
+    </param>
+    <param>
+      <key>nconnections</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>ref_level</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>showports</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>update_time</key>
+      <value>0.20</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>52</value>
+    </param>
+    <param>
+      <key>x_axis_label</key>
+      <value>"x-Axis"</value>
+    </param>
+    <param>
+      <key>x_start</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>x_step</key>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>x_units</key>
+      <value>""</value>
+    </param>
+    <param>
+      <key>ymax</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>ymin</key>
+      <value>-1</value>
+    </param>
+    <param>
+      <key>y_axis_label</key>
+      <value>"y-Axis"</value>
+    </param>
+    <param>
+      <key>y_units</key>
+      <value>""</value>
+    </param>
+  </block>
+  <block>
     <key>uhd_usrp_source</key>
     <param>
       <key>alias</key>
@@ -2261,7 +2587,7 @@
     </param>
     <param>
       <key>ant0</key>
-      <value></value>
+      <value>J1</value>
     </param>
     <param>
       <key>bw0</key>
@@ -2273,11 +2599,11 @@
     </param>
     <param>
       <key>dc_offs_enb0</key>
-      <value>""</value>
+      <value>True</value>
     </param>
     <param>
       <key>iq_imbal_enb0</key>
-      <value>""</value>
+      <value>True</value>
     </param>
     <param>
       <key>norm_gain0</key>
@@ -3593,6 +3919,18 @@
     </param>
   </block>
   <connection>
+    <source_block_id>blocks_complex_to_float_0</source_block_id>
+    <sink_block_id>qtgui_vector_sink_f_0_0</sink_block_id>
+    <source_key>1</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_complex_to_float_0</source_block_id>
+    <sink_block_id>qtgui_vector_sink_f_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_complex_to_mag_0</source_block_id>
     <sink_block_id>blocks_divide_xx_0</sink_block_id>
     <source_key>0</source_key>
@@ -3660,7 +3998,7 @@
   </connection>
   <connection>
     <source_block_id>fft_vxx_0</source_block_id>
-    <sink_block_id>ieee802_11_frame_equalizer_0</sink_block_id>
+    <sink_block_id>ieee802_11_frame_equalizer_csi_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -3683,13 +4021,19 @@
     <sink_key>in</sink_key>
   </connection>
   <connection>
-    <source_block_id>ieee802_11_frame_equalizer_0</source_block_id>
+    <source_block_id>ieee802_11_frame_equalizer_csi_0</source_block_id>
+    <sink_block_id>blocks_complex_to_float_0</sink_block_id>
+    <source_key>1</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>ieee802_11_frame_equalizer_csi_0</source_block_id>
     <sink_block_id>ieee802_11_decode_mac_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>ieee802_11_frame_equalizer_0</source_block_id>
+    <source_block_id>ieee802_11_frame_equalizer_csi_0</source_block_id>
     <sink_block_id>blocks_pdu_to_tagged_stream_1</sink_block_id>
     <source_key>symbols</source_key>
     <sink_key>pdus</sink_key>

--- a/examples/wifi_tx.grc
+++ b/examples/wifi_tx.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.8.git'?>
+<?grc format='1' created='3.7.14'?>
 <flow_graph>
   <timestamp>Fri Apr 17 13:08:32 2015</timestamp>
   <block>
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -815,7 +823,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(640, 448)</value>
+      <value>(744, 448)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1890,7 +1898,7 @@
     </param>
     <param>
       <key>frequency</key>
-      <value>5.89e9</value>
+      <value>freq</value>
     </param>
     <param>
       <key>sensitivity</key>

--- a/grc/ieee802_11_frame_equalizer.xml
+++ b/grc/ieee802_11_frame_equalizer.xml
@@ -99,7 +99,6 @@
 		<type>complex</type>
 		<vlen>52</vlen>
 		<nports>1</nports>
-		<optional>1</optional>
 	</source>
 
 	<source>

--- a/grc/ieee802_11_frame_equalizer.xml
+++ b/grc/ieee802_11_frame_equalizer.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <block>
-	<name>WiFi Frame Equalizer</name>
-	<key>ieee802_11_frame_equalizer</key>
+	<name>WiFi Frame Equalizer_csi</name>
+	<key>ieee802_11_frame_equalizer_csi</key>
 	<category>[IEEE802.11]</category>
 	<import>import ieee802_11</import>
 	<make>ieee802_11.frame_equalizer($algo, $freq, $bw, $log, $debug)</make>
@@ -92,6 +92,14 @@
 		<type>byte</type>
 		<vlen>48</vlen>
 		<nports>1</nports>
+	</source>
+
+	<source>
+		<name>CSI</name>
+		<type>complex</type>
+		<vlen>52</vlen>
+		<nports>1</nports>
+		<optional>1</optional>
 	</source>
 
 	<source>

--- a/grc/ieee802_11_frame_equalizer_csi.xml
+++ b/grc/ieee802_11_frame_equalizer_csi.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 
 <block>
-	<name>WiFi Frame Equalizer_csi</name>
+	<name>WiFi Frame Equalizer CSI</name>
 	<key>ieee802_11_frame_equalizer_csi</key>
 	<category>[IEEE802.11]</category>
 	<import>import ieee802_11</import>
-	<make>ieee802_11.frame_equalizer($algo, $freq, $bw, $log, $debug)</make>
+	<make>ieee802_11.frame_equalizer_csi($algo, $freq, $bw, $log, $debug)</make>
 	<callback>set_algorithm($algo)</callback>
 	<callback>set_frequency($freq)</callback>
 	<callback>set_bandwidth($bw)</callback>

--- a/grc/ieee802_11_frame_equalizer_csi.xml
+++ b/grc/ieee802_11_frame_equalizer_csi.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <block>
-	<name>WiFi Frame Equalizer</name>
-	<key>ieee802_11_frame_equalizer</key>
+	<name>WiFi Frame Equalizer_csi</name>
+	<key>ieee802_11_frame_equalizer_csi</key>
 	<category>[IEEE802.11]</category>
 	<import>import ieee802_11</import>
 	<make>ieee802_11.frame_equalizer($algo, $freq, $bw, $log, $debug)</make>
@@ -91,6 +91,13 @@
 		<name>out</name>
 		<type>byte</type>
 		<vlen>48</vlen>
+		<nports>1</nports>
+	</source>
+
+	<source>
+		<name>CSI</name>
+		<type>complex</type>
+		<vlen>52</vlen>
 		<nports>1</nports>
 	</source>
 

--- a/grc/ieee802_11_frame_equalizer_csi.xml
+++ b/grc/ieee802_11_frame_equalizer_csi.xml
@@ -95,8 +95,15 @@
 	</source>
 
 	<source>
-		<name>CSI</name>
-		<type>complex</type>
+		<name>Subcarrier Power</name>
+		<type>float64</type>
+		<vlen>52</vlen>
+		<nports>1</nports>
+	</source>
+
+	<source>
+		<name>Subcarrier Noise</name>
+		<type>float64</type>
 		<vlen>52</vlen>
 		<nports>1</nports>
 	</source>

--- a/grc/ieee802_11_parse_mac.xml
+++ b/grc/ieee802_11_parse_mac.xml
@@ -49,6 +49,11 @@
 		<type>message</type>
 		<optional>1</optional>
 	</source>
+	<source>
+		<name>message</name>
+		<type>message</type>
+		<optional>1</optional>
+	</source>
 
 </block>
 

--- a/include/ieee802-11/CMakeLists.txt
+++ b/include/ieee802-11/CMakeLists.txt
@@ -74,6 +74,7 @@ list(APPEND include_sources
     decode_mac.h
     ether_encap.h
     frame_equalizer.h
+    frame_equalizer_csi.h
     mac.h
     mapper.h
     parse_mac.h

--- a/include/ieee802-11/frame_equalizer_csi.h
+++ b/include/ieee802-11/frame_equalizer_csi.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 Bastian Bloessl <bloessl@ccs-labs.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#ifndef INCLUDED_IEEE802_11_FRAME_EQUALIZER_CSI_H
+#define INCLUDED_IEEE802_11_FRAME_EQUALIZER_CSI_H
+
+#include <ieee802-11/api.h>
+#include <gnuradio/block.h>
+#include <ieee802-11/frame_equalizer.h>
+
+namespace gr {
+namespace ieee802_11 {
+
+class IEEE802_11_API frame_equalizer_csi : virtual public gr::block
+{
+
+public:
+	typedef boost::shared_ptr<frame_equalizer_csi> sptr;
+	static sptr make(Equalizer algo, double freq, double bw,
+			bool log, bool debug);
+	virtual void set_algorithm(Equalizer algo) = 0;
+	virtual void set_bandwidth(double bw) = 0;
+	virtual void set_frequency(double freq) = 0;
+};
+
+} // namespace ieee802_11
+} // namespace gr
+
+#endif /* INCLUDED_IEEE802_11_FRAME_EQUALIZER_CSI_H */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -104,6 +104,7 @@ list(APPEND gr_ieee802_11_sources
     equalizer/sta.cc
     ether_encap_impl.cc
     frame_equalizer_impl.cc
+    frame_equalizer_csi_impl.cc
     mac.cc
     mapper.cc
     parse_mac.cc

--- a/lib/equalizer/base.h
+++ b/lib/equalizer/base.h
@@ -28,7 +28,7 @@ namespace equalizer {
 class base {
 public:
 	virtual ~base() {};
-	virtual void equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) = 0;
+	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) = 0;
 	virtual double get_snr() = 0;
 
 	static const gr_complex POLARITY[127];

--- a/lib/equalizer/base.h
+++ b/lib/equalizer/base.h
@@ -28,7 +28,7 @@ namespace equalizer {
 class base {
 public:
 	virtual ~base() {};
-	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) = 0;
+	virtual double * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) = 0;
 	virtual double get_snr() = 0;
 
 	static const gr_complex POLARITY[127];

--- a/lib/equalizer/comb.cc
+++ b/lib/equalizer/comb.cc
@@ -19,7 +19,7 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-void comb::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+gr_complex * comb::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
 
 	gr_complex pilot[4];
 
@@ -69,6 +69,8 @@ void comb::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, b
 			c++;
 		}
 	}
+
+	return d_H;
 }
 
 double

--- a/lib/equalizer/comb.cc
+++ b/lib/equalizer/comb.cc
@@ -19,7 +19,7 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-gr_complex * comb::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+double * comb::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
 
 	gr_complex pilot[4];
 
@@ -69,8 +69,8 @@ gr_complex * comb::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t 
 			c++;
 		}
 	}
-
-	return d_H;
+	// TODO(br): calculate signal and noise power per subcarrier
+	return 0, 0;
 }
 
 double

--- a/lib/equalizer/comb.h
+++ b/lib/equalizer/comb.h
@@ -26,7 +26,7 @@ namespace equalizer {
 
 class comb: public base {
 public:
-	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual double * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 	double get_snr();
 
 private:

--- a/lib/equalizer/comb.h
+++ b/lib/equalizer/comb.h
@@ -26,7 +26,7 @@ namespace equalizer {
 
 class comb: public base {
 public:
-	virtual void equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 	double get_snr();
 
 private:

--- a/lib/equalizer/lms.cc
+++ b/lib/equalizer/lms.cc
@@ -21,7 +21,7 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-void lms::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+gr_complex * lms::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
 
 	if(n == 0) {
 		std::memcpy(d_H, in, 64 * sizeof(gr_complex));
@@ -56,6 +56,8 @@ void lms::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, bo
 			}
 		}
 	}
+
+	return d_H;
 }
 
 double

--- a/lib/equalizer/lms.cc
+++ b/lib/equalizer/lms.cc
@@ -21,20 +21,26 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-gr_complex * lms::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
-
+double * lms::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+	double signals[52];
+	double noises[52];
+	
 	if(n == 0) {
 		std::memcpy(d_H, in, 64 * sizeof(gr_complex));
 
 	} else if(n == 1) {
 		double signal = 0;
 		double noise = 0;
+		double* signals = new double[52];
+		double* noises = new double[52];
 		for(int i = 0; i < 64; i++) {
 			if((i == 32) || (i < 6) || ( i > 58)) {
 				continue;
 			}
 			noise += std::pow(std::abs(d_H[i] - in[i]), 2);
+			noises[i] = noise;
 			signal += std::pow(std::abs(d_H[i] + in[i]), 2);
+			signals[i]= signal;
 			d_H[i] += in[i];
 			d_H[i] /= LONG[i] * gr_complex(2, 0);
 		}
@@ -57,7 +63,7 @@ gr_complex * lms::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *
 		}
 	}
 
-	return d_H;
+	return signals, noises;
 }
 
 double

--- a/lib/equalizer/lms.h
+++ b/lib/equalizer/lms.h
@@ -27,7 +27,7 @@ namespace equalizer {
 
 class lms: public base {
 public:
-	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual double * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 private:
 	double get_snr();
 

--- a/lib/equalizer/lms.h
+++ b/lib/equalizer/lms.h
@@ -27,7 +27,7 @@ namespace equalizer {
 
 class lms: public base {
 public:
-	virtual void equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 private:
 	double get_snr();
 

--- a/lib/equalizer/ls.cc
+++ b/lib/equalizer/ls.cc
@@ -21,7 +21,7 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-void ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+gr_complex * ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
 
 	if(n == 0) {
 		std::memcpy(d_H, in, 64 * sizeof(gr_complex));
@@ -54,6 +54,8 @@ void ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boo
 			}
 		}
 	}
+
+	return d_H;
 }
 
 double ls::get_snr() {

--- a/lib/equalizer/ls.cc
+++ b/lib/equalizer/ls.cc
@@ -18,10 +18,13 @@
 #include "ls.h"
 #include <cstring>
 #include <iostream>
+#include <map>
 
 using namespace gr::ieee802_11::equalizer;
 
-gr_complex * ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+double * ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+	double signals[52];
+	double noises[52];
 
 	if(n == 0) {
 		std::memcpy(d_H, in, 64 * sizeof(gr_complex));
@@ -29,12 +32,16 @@ gr_complex * ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *b
 	} else if(n == 1) {
 		double signal = 0;
 		double noise = 0;
+		double* signals = new double[52];
+		double* noises = new double[52];
 		for(int i = 0; i < 64; i++) {
 			if((i == 32) || (i < 6) || ( i > 58)) {
 				continue;
 			}
 			noise += std::pow(std::abs(d_H[i] - in[i]), 2);
+			noises[i] = noise;
 			signal += std::pow(std::abs(d_H[i] + in[i]), 2);
+			signals[i] = signal;
 			d_H[i] += in[i];
 			d_H[i] /= LONG[i] * gr_complex(2, 0);
 		}
@@ -55,7 +62,7 @@ gr_complex * ls::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *b
 		}
 	}
 
-	return d_H;
+	return signals, noises;
 }
 
 double ls::get_snr() {

--- a/lib/equalizer/ls.h
+++ b/lib/equalizer/ls.h
@@ -27,7 +27,7 @@ namespace equalizer {
 
 class ls: public base {
 public:
-	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual double * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 	virtual double get_snr();
 private:
 	gr_complex d_H[64];

--- a/lib/equalizer/ls.h
+++ b/lib/equalizer/ls.h
@@ -27,7 +27,7 @@ namespace equalizer {
 
 class ls: public base {
 public:
-	virtual void equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 	virtual double get_snr();
 private:
 	gr_complex d_H[64];

--- a/lib/equalizer/sta.cc
+++ b/lib/equalizer/sta.cc
@@ -21,7 +21,7 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-void sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+gr_complex * sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
 
 	if(n == 0) {
 		std::memcpy(d_H, in, 64 * sizeof(gr_complex));
@@ -87,6 +87,8 @@ void sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, bo
 			d_H[i] = gr_complex(1-alpha,0) * d_H[i] + gr_complex(alpha,0) * H_update[i];
 		}
 	}
+
+	return d_H;
 }
 
 double

--- a/lib/equalizer/sta.cc
+++ b/lib/equalizer/sta.cc
@@ -21,7 +21,9 @@
 
 using namespace gr::ieee802_11::equalizer;
 
-gr_complex * sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+double * sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod) {
+	double signals[52];
+	double noises[52];
 
 	if(n == 0) {
 		std::memcpy(d_H, in, 64 * sizeof(gr_complex));
@@ -29,12 +31,16 @@ gr_complex * sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *
 	} else if(n == 1) {
 		double signal = 0;
 		double noise = 0;
+		double* signals = new double[52];
+		double* noises = new double[52];
 		for(int i = 0; i < 64; i++) {
 			if((i == 32) || (i < 6) || ( i > 58)) {
 				continue;
 			}
 			noise += std::pow(std::abs(d_H[i] - in[i]), 2);
+			noises[i] = noise;
 			signal += std::pow(std::abs(d_H[i] + in[i]), 2);
+			signals[i] = signal;
 			d_H[i] += in[i];
 			d_H[i] /= LONG[i] * gr_complex(2, 0);
 		}
@@ -88,7 +94,7 @@ gr_complex * sta::equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *
 		}
 	}
 
-	return d_H;
+	return signals, noises;
 }
 
 double

--- a/lib/equalizer/sta.h
+++ b/lib/equalizer/sta.h
@@ -27,7 +27,7 @@ namespace equalizer {
 
 class sta: public base {
 public:
-	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual double * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 	double get_snr();
 
 private:

--- a/lib/equalizer/sta.h
+++ b/lib/equalizer/sta.h
@@ -27,7 +27,7 @@ namespace equalizer {
 
 class sta: public base {
 public:
-	virtual void equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
+	virtual gr_complex * equalize(gr_complex *in, int n, gr_complex *symbols, uint8_t *bits, boost::shared_ptr<gr::digital::constellation> mod);
 	double get_snr();
 
 private:

--- a/lib/frame_equalizer_csi_impl.cc
+++ b/lib/frame_equalizer_csi_impl.cc
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "frame_equalizer_impl.h"
+#include "frame_equalizer_csi_impl.h"
 #include "equalizer/base.h"
 #include "equalizer/comb.h"
 #include "equalizer/lms.h"
@@ -27,15 +27,15 @@
 namespace gr {
 namespace ieee802_11 {
 
-frame_equalizer::sptr
-frame_equalizer::make(Equalizer algo, double freq, double bw, bool log, bool debug) {
+frame_equalizer_csi::sptr
+frame_equalizer_csi::make(Equalizer algo, double freq, double bw, bool log, bool debug) {
 	return gnuradio::get_initial_sptr
-		(new frame_equalizer_impl(algo, freq, bw, log, debug));
+		(new frame_equalizer_csi_impl(algo, freq, bw, log, debug));
 }
 
 
-frame_equalizer_impl::frame_equalizer_impl(Equalizer algo, double freq, double bw, bool log, bool debug) :
-	gr::block("frame_equalizer",
+frame_equalizer_csi_impl::frame_equalizer_csi_impl(Equalizer algo, double freq, double bw, bool log, bool debug) :
+	gr::block("frame_equalizer_csi",
 			gr::io_signature::make(1, 1, 64 * sizeof(gr_complex)),
 			gr::io_signature::make2(2, 2, 48, 52 * sizeof(gr_complex))),
 	d_current_symbol(0), d_log(log), d_debug(debug), d_equalizer(NULL),
@@ -55,12 +55,12 @@ frame_equalizer_impl::frame_equalizer_impl(Equalizer algo, double freq, double b
 	set_algorithm(algo);
 }
 
-frame_equalizer_impl::~frame_equalizer_impl() {
+frame_equalizer_csi_impl::~frame_equalizer_csi_impl() {
 }
 
 
 void
-frame_equalizer_impl::set_algorithm(Equalizer algo) {
+frame_equalizer_csi_impl::set_algorithm(Equalizer algo) {
 	gr::thread::scoped_lock lock(d_mutex);
 	delete d_equalizer;
 
@@ -88,24 +88,24 @@ frame_equalizer_impl::set_algorithm(Equalizer algo) {
 }
 
 void
-frame_equalizer_impl::set_bandwidth(double bw) {
+frame_equalizer_csi_impl::set_bandwidth(double bw) {
 	gr::thread::scoped_lock lock(d_mutex);
 	d_bw = bw;
 }
 
 void
-frame_equalizer_impl::set_frequency(double freq) {
+frame_equalizer_csi_impl::set_frequency(double freq) {
 	gr::thread::scoped_lock lock(d_mutex);
 	d_freq = freq;
 }
 
 void
-frame_equalizer_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required) {
+frame_equalizer_csi_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required) {
 	ninput_items_required[0] = noutput_items;
 }
 
 int
-frame_equalizer_impl::general_work (int noutput_items,
+frame_equalizer_csi_impl::general_work (int noutput_items,
 		gr_vector_int &ninput_items,
 		gr_vector_const_void_star &input_items,
 		gr_vector_void_star &output_items) {
@@ -238,7 +238,7 @@ frame_equalizer_impl::general_work (int noutput_items,
 }
 
 bool
-frame_equalizer_impl::decode_signal_field(uint8_t *rx_bits) {
+frame_equalizer_csi_impl::decode_signal_field(uint8_t *rx_bits) {
 
 	static ofdm_param ofdm(BPSK_1_2);
 	static frame_param frame(ofdm, 0);
@@ -250,14 +250,14 @@ frame_equalizer_impl::decode_signal_field(uint8_t *rx_bits) {
 }
 
 void
-frame_equalizer_impl::deinterleave(uint8_t *rx_bits) {
+frame_equalizer_csi_impl::deinterleave(uint8_t *rx_bits) {
 	for(int i = 0; i < 48; i++) {
 		d_deinterleaved[i] = rx_bits[interleaver_pattern[i]];
 	}
 }
 
 bool
-frame_equalizer_impl::parse_signal(uint8_t *decoded_bits) {
+frame_equalizer_csi_impl::parse_signal(uint8_t *decoded_bits) {
 
 	int r = 0;
 	d_frame_bytes = 0;
@@ -339,7 +339,7 @@ frame_equalizer_impl::parse_signal(uint8_t *decoded_bits) {
 }
 
 const int
-frame_equalizer_impl::interleaver_pattern[48] = {
+frame_equalizer_csi_impl::interleaver_pattern[48] = {
 	 0, 3, 6, 9,12,15,18,21,
 	24,27,30,33,36,39,42,45,
 	 1, 4, 7,10,13,16,19,22,

--- a/lib/frame_equalizer_csi_impl.cc
+++ b/lib/frame_equalizer_csi_impl.cc
@@ -201,9 +201,12 @@ frame_equalizer_csi_impl::general_work (int noutput_items,
 			d_er = (1-alpha) * d_er + alpha * er;
 		}
 
-		// do equalization
+		// do equalization and add propagate the last tag if tags are present
 		csi_out[i] = * d_equalizer->equalize(current_symbol, d_current_symbol,
 										symbols, out + o * 48, d_frame_mod);
+		if (tags.size()){
+			gr::block::add_item_tag(1, tags.back());
+		}
 
 		// signal field
 		if(d_current_symbol == 2) {

--- a/lib/frame_equalizer_csi_impl.cc
+++ b/lib/frame_equalizer_csi_impl.cc
@@ -37,7 +37,7 @@ frame_equalizer::make(Equalizer algo, double freq, double bw, bool log, bool deb
 frame_equalizer_impl::frame_equalizer_impl(Equalizer algo, double freq, double bw, bool log, bool debug) :
 	gr::block("frame_equalizer",
 			gr::io_signature::make(1, 1, 64 * sizeof(gr_complex)),
-			gr::io_signature::make(1, 1, 48)),
+			gr::io_signature::make2(2, 2, 48, 52 * sizeof(gr_complex))),
 	d_current_symbol(0), d_log(log), d_debug(debug), d_equalizer(NULL),
 	d_freq(freq), d_bw(bw), d_frame_bytes(0), d_frame_symbols(0),
 	d_freq_offset_from_synclong(0.0) {
@@ -114,6 +114,7 @@ frame_equalizer_impl::general_work (int noutput_items,
 
 	const gr_complex *in = (const gr_complex *) input_items[0];
 	uint8_t *out = (uint8_t *) output_items[0];
+	gr_complex *csi_out = (gr_complex *) output_items[1];
 
 	int i = 0;
 	int o = 0;
@@ -201,8 +202,8 @@ frame_equalizer_impl::general_work (int noutput_items,
 		}
 
 		// do equalization
-		d_equalizer->equalize(current_symbol, d_current_symbol,
-								symbols, out + o * 48, d_frame_mod);
+		csi_out[i] = * d_equalizer->equalize(current_symbol, d_current_symbol,
+										symbols, out + o * 48, d_frame_mod);
 
 		// signal field
 		if(d_current_symbol == 2) {

--- a/lib/frame_equalizer_csi_impl.h
+++ b/lib/frame_equalizer_csi_impl.h
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef INCLUDED_IEEE802_11_FRAME_EQUALIZER_IMPL_H
-#define INCLUDED_IEEE802_11_FRAME_EQUALIZER_IMPL_H
+#ifndef INCLUDED_IEEE802_11_FRAME_EQUALIZER_CSI_IMPL_H
+#define INCLUDED_IEEE802_11_FRAME_EQUALIZER_CSI_IMPL_H
 
-#include <ieee802-11/frame_equalizer.h>
+#include <ieee802-11/frame_equalizer_csi.h>
 #include <ieee802-11/constellations.h>
 #include "equalizer/base.h"
 #include "viterbi_decoder.h"
@@ -26,12 +26,12 @@
 namespace gr {
 namespace ieee802_11 {
 
-class frame_equalizer_impl : virtual public frame_equalizer
+class frame_equalizer_csi_impl : virtual public frame_equalizer_csi
 {
 
 public:
-	frame_equalizer_impl(Equalizer algo, double freq, double bw, bool log, bool debug);
-	~frame_equalizer_impl();
+	frame_equalizer_csi_impl(Equalizer algo, double freq, double bw, bool log, bool debug);
+	~frame_equalizer_csi_impl();
 
 	void set_algorithm(Equalizer algo);
 	void set_bandwidth(double bw);
@@ -86,4 +86,4 @@ private:
 } // namespace ieee802_11
 } // namespace gr
 
-#endif /* INCLUDED_IEEE802_11_FRAME_EQUALIZER_IMPL_H */
+#endif /* INCLUDED_IEEE802_11_FRAME_EQUALIZER_CSI_IMPL_H */

--- a/lib/frame_equalizer_csi_impl.h
+++ b/lib/frame_equalizer_csi_impl.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016 Bastian Bloessl <bloessl@ccs-labs.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INCLUDED_IEEE802_11_FRAME_EQUALIZER_IMPL_H
+#define INCLUDED_IEEE802_11_FRAME_EQUALIZER_IMPL_H
+
+#include <ieee802-11/frame_equalizer.h>
+#include <ieee802-11/constellations.h>
+#include "equalizer/base.h"
+#include "viterbi_decoder.h"
+
+namespace gr {
+namespace ieee802_11 {
+
+class frame_equalizer_impl : virtual public frame_equalizer
+{
+
+public:
+	frame_equalizer_impl(Equalizer algo, double freq, double bw, bool log, bool debug);
+	~frame_equalizer_impl();
+
+	void set_algorithm(Equalizer algo);
+	void set_bandwidth(double bw);
+	void set_frequency(double freq);
+
+	void forecast (int noutput_items, gr_vector_int &ninput_items_required);
+	int general_work(int noutput_items,
+			gr_vector_int &ninput_items,
+			gr_vector_const_void_star &input_items,
+			gr_vector_void_star &output_items);
+
+private:
+
+
+	bool parse_signal(uint8_t *signal);
+	bool decode_signal_field(uint8_t *rx_bits);
+	void deinterleave(uint8_t *rx_bits);
+
+	equalizer::base *d_equalizer;
+	gr::thread::mutex d_mutex;
+	std::vector<gr::tag_t> tags;
+	bool d_debug;
+	bool d_log;
+	int  d_current_symbol;
+	viterbi_decoder d_decoder;
+
+	// freq offset
+	double d_freq;  // Hz
+	double d_freq_offset_from_synclong;  // Hz, estimation from "sync_long" block
+	double d_bw;  // Hz
+	double d_er;
+	double d_epsilon0;
+	gr_complex d_prev_pilots[4];
+
+	int  d_frame_bytes;
+	int  d_frame_symbols;
+	int  d_frame_encoding;
+
+	uint8_t d_deinterleaved[48];
+	gr_complex symbols[48];
+	gr_complex csi[52];
+
+	boost::shared_ptr<gr::digital::constellation> d_frame_mod;
+	constellation_bpsk::sptr d_bpsk;
+	constellation_qpsk::sptr d_qpsk;
+	constellation_16qam::sptr d_16qam;
+	constellation_64qam::sptr d_64qam;
+
+	static const int interleaver_pattern[48];
+};
+
+} // namespace ieee802_11
+} // namespace gr
+
+#endif /* INCLUDED_IEEE802_11_FRAME_EQUALIZER_IMPL_H */

--- a/lib/frame_equalizer_impl.cc
+++ b/lib/frame_equalizer_impl.cc
@@ -37,7 +37,7 @@ frame_equalizer::make(Equalizer algo, double freq, double bw, bool log, bool deb
 frame_equalizer_impl::frame_equalizer_impl(Equalizer algo, double freq, double bw, bool log, bool debug) :
 	gr::block("frame_equalizer",
 			gr::io_signature::make(1, 1, 64 * sizeof(gr_complex)),
-			gr::io_signature::make(1, 1, 48)),
+			gr::io_signature::make2(1, 2, 48, 52 * sizeof(gr_complex))),
 	d_current_symbol(0), d_log(log), d_debug(debug), d_equalizer(NULL),
 	d_freq(freq), d_bw(bw), d_frame_bytes(0), d_frame_symbols(0),
 	d_freq_offset_from_synclong(0.0) {
@@ -114,6 +114,7 @@ frame_equalizer_impl::general_work (int noutput_items,
 
 	const gr_complex *in = (const gr_complex *) input_items[0];
 	uint8_t *out = (uint8_t *) output_items[0];
+	gr_complex *csi_out = (gr_complex *) output_items[1];
 
 	int i = 0;
 	int o = 0;
@@ -201,8 +202,8 @@ frame_equalizer_impl::general_work (int noutput_items,
 		}
 
 		// do equalization
-		d_equalizer->equalize(current_symbol, d_current_symbol,
-				symbols, out + o * 48, d_frame_mod);
+		csi_out[i] = * d_equalizer->equalize(current_symbol, d_current_symbol,
+										symbols, out + o * 48, d_frame_mod);
 
 		// signal field
 		if(d_current_symbol == 2) {

--- a/lib/frame_equalizer_impl.cc
+++ b/lib/frame_equalizer_impl.cc
@@ -37,7 +37,7 @@ frame_equalizer::make(Equalizer algo, double freq, double bw, bool log, bool deb
 frame_equalizer_impl::frame_equalizer_impl(Equalizer algo, double freq, double bw, bool log, bool debug) :
 	gr::block("frame_equalizer",
 			gr::io_signature::make(1, 1, 64 * sizeof(gr_complex)),
-			gr::io_signature::make2(1, 2, 48, 52 * sizeof(gr_complex))),
+			gr::io_signature::make2(2, 2, 48, 52 * sizeof(gr_complex))),
 	d_current_symbol(0), d_log(log), d_debug(debug), d_equalizer(NULL),
 	d_freq(freq), d_bw(bw), d_frame_bytes(0), d_frame_symbols(0),
 	d_freq_offset_from_synclong(0.0) {

--- a/lib/frame_equalizer_impl.h
+++ b/lib/frame_equalizer_impl.h
@@ -72,6 +72,7 @@ private:
 
 	uint8_t d_deinterleaved[48];
 	gr_complex symbols[48];
+	gr_complex csi[52];
 
 	boost::shared_ptr<gr::digital::constellation> d_frame_mod;
 	constellation_bpsk::sptr d_bpsk;

--- a/swig/ieee802_11_swig.i
+++ b/swig/ieee802_11_swig.i
@@ -27,6 +27,7 @@
 #include "ieee802-11/decode_mac.h"
 #include "ieee802-11/ether_encap.h"
 #include "ieee802-11/frame_equalizer.h"
+#include "ieee802-11/frame_equalizer_csi.h"
 #include "ieee802-11/mac.h"
 #include "ieee802-11/mapper.h"
 #include "ieee802-11/moving_average_cc.h"
@@ -49,6 +50,7 @@
 %include "ieee802-11/decode_mac.h"
 %include "ieee802-11/ether_encap.h"
 %include "ieee802-11/frame_equalizer.h"
+%include "ieee802-11/frame_equalizer_csi.h"
 %include "ieee802-11/mac.h"
 %include "ieee802-11/mapper.h"
 %include "ieee802-11/moving_average_cc.h"
@@ -62,6 +64,7 @@ GR_SWIG_BLOCK_MAGIC2(ieee802_11, chunks_to_symbols);
 GR_SWIG_BLOCK_MAGIC2(ieee802_11, decode_mac);
 GR_SWIG_BLOCK_MAGIC2(ieee802_11, ether_encap);
 GR_SWIG_BLOCK_MAGIC2(ieee802_11, frame_equalizer);
+GR_SWIG_BLOCK_MAGIC2(ieee802_11, frame_equalizer_csi);
 GR_SWIG_BLOCK_MAGIC2(ieee802_11, mac);
 GR_SWIG_BLOCK_MAGIC2(ieee802_11, mapper);
 GR_SWIG_BLOCK_MAGIC2(ieee802_11, moving_average_cc);


### PR DESCRIPTION
As it was asked multiple times and I needed it again I introduced a frameequalizer_block which exposes the CSI-values (without breaking existing workflows) and additionally I also exposed the message from the decode_mac as I need it in my code (maybe not as useful for others)