### PR TITLE
Make metadata pipeline more uniform and GR-like.

### DIFF
--- a/lib/decode_mac.cc
+++ b/lib/decode_mac.cc
@@ -78,7 +78,7 @@ public:
                     d_meta = pmt::dict_add(d_meta, tag.key, tag.value);
 
                 int len_data = pmt::to_uint64(pmt::dict_ref(
-                    d_meta, pmt::mp("frame_bytes"), pmt::from_uint64(MAX_PSDU_SIZE + 1)));
+                    d_meta, pmt::mp("frame bytes"), pmt::from_uint64(MAX_PSDU_SIZE + 1)));
                 int encoding = pmt::to_uint64(
                     pmt::dict_ref(d_meta, pmt::mp("encoding"), pmt::from_uint64(0)));
 

--- a/lib/decode_mac.cc
+++ b/lib/decode_mac.cc
@@ -36,14 +36,10 @@ public:
                 gr::io_signature::make(0, 0, 0)),
           d_log(log),
           d_debug(debug),
-          d_snr(0),
-          d_nom_freq(0.0),
-          d_freq_offset(0.0),
           d_ofdm(BPSK_1_2),
           d_frame(d_ofdm, 0),
           d_frame_complete(true)
     {
-
         message_port_register_out(pmt::mp("out"));
     }
 
@@ -64,8 +60,7 @@ public:
 
         while (i < ninput_items[0]) {
 
-            get_tags_in_range(
-                tags, 0, nread + i, nread + i + 1, pmt::string_to_symbol("wifi_start"));
+            get_tags_in_range(tags, 0, nread + i, nread + i + 1);
 
             if (tags.size()) {
                 if (d_frame_complete == false) {
@@ -77,21 +72,16 @@ public:
                 }
                 d_frame_complete = false;
 
-                pmt::pmt_t dict = tags[0].value;
+                // Enter tags into metadata dictionary
+                d_meta = pmt::make_dict();
+                for (auto tag : tags)
+                    d_meta = pmt::dict_add(d_meta, tag.key, tag.value);
+
                 int len_data = pmt::to_uint64(pmt::dict_ref(
-                    dict, pmt::mp("frame_bytes"), pmt::from_uint64(MAX_PSDU_SIZE + 1)));
+                    d_meta, pmt::mp("frame_bytes"), pmt::from_uint64(MAX_PSDU_SIZE + 1)));
                 int encoding = pmt::to_uint64(
-                    pmt::dict_ref(dict, pmt::mp("encoding"), pmt::from_uint64(0)));
-                d_snr = pmt::to_double(
-                    pmt::dict_ref(dict, pmt::mp("snr"), pmt::from_double(0)));
-                d_nom_freq = pmt::to_double(
-                    pmt::dict_ref(dict, pmt::mp("freq"), pmt::from_double(0)));
-                d_freq_offset = pmt::to_double(
-                    pmt::dict_ref(dict, pmt::mp("freq_offset"), pmt::from_double(0)));
-                d_beta = pmt::to_double(
-                    pmt::dict_ref(dict, pmt::mp("beta"), pmt::from_double(0)));
-                d_csi = pmt::c32vector_elements(
-                    pmt::dict_ref(dict, pmt::mp("csi"), pmt::make_c32vector(52, 0)));
+                    pmt::dict_ref(d_meta, pmt::mp("encoding"), pmt::from_uint64(0)));
+
                 ofdm_param ofdm = ofdm_param((Encoding)encoding);
                 frame_param frame = frame_param(ofdm, len_data);
 
@@ -160,16 +150,10 @@ public:
 
         // create PDU
         pmt::pmt_t blob = pmt::make_blob(out_bytes + 2, d_frame.psdu_size - 4);
-        pmt::pmt_t enc = pmt::from_uint64(d_ofdm.encoding);
-        pmt::pmt_t dict = pmt::make_dict();
-        dict = pmt::dict_add(dict, pmt::mp("encoding"), enc);
-        dict = pmt::dict_add(dict, pmt::mp("snr"), pmt::from_double(d_snr));
-        dict = pmt::dict_add(dict, pmt::mp("nomfreq"), pmt::from_double(d_nom_freq));
-        dict = pmt::dict_add(dict, pmt::mp("freqofs"), pmt::from_double(d_freq_offset));
-        dict = pmt::dict_add(dict, pmt::mp("beta"), pmt::from_double(d_beta));
-        dict = pmt::dict_add(dict, pmt::mp("csi"), pmt::init_c32vector(52, d_csi));
-        dict = pmt::dict_add(dict, pmt::mp("dlt"), pmt::from_long(LINKTYPE_IEEE802_11));
-        message_port_pub(pmt::mp("out"), pmt::cons(dict, blob));
+        d_meta = pmt::dict_add(
+            d_meta, pmt::mp("dlt"), pmt::from_long(LINKTYPE_IEEE802_11));
+
+        message_port_pub(pmt::mp("out"), pmt::cons(d_meta, blob));
     }
 
     void deinterleave()
@@ -249,13 +233,11 @@ private:
     bool d_debug;
     bool d_log;
 
+    pmt::pmt_t d_meta;
+
     frame_param d_frame;
     ofdm_param d_ofdm;
-    double d_snr;         // dB
-    double d_nom_freq;    // nominal frequency, Hz
-    double d_freq_offset; // frequency offset, Hz
-    double d_beta;
-    std::vector<gr_complex> d_csi;
+
     viterbi_decoder d_decoder;
 
     uint8_t d_rx_symbols[48 * MAX_SYM];

--- a/lib/frame_equalizer_impl.cc
+++ b/lib/frame_equalizer_impl.cc
@@ -224,7 +224,7 @@ int frame_equalizer_impl::general_work(int noutput_items,
                     dict, pmt::mp("encoding"), pmt::from_uint64(d_frame_encoding));
                 dict = pmt::dict_add(
                     dict, pmt::mp("snr"), pmt::from_double(d_equalizer->get_snr()));
-                dict = pmt::dict_add(dict, pmt::mp("freq"), pmt::from_double(d_freq));
+                dict = pmt::dict_add(dict, pmt::mp("nom_freq"), pmt::from_double(d_freq));
                 dict = pmt::dict_add(dict,
                                      pmt::mp("freq_offset"),
                                      pmt::from_double(d_freq_offset_from_synclong));
@@ -234,11 +234,16 @@ int frame_equalizer_impl::general_work(int noutput_items,
                 dict = pmt::dict_add(
                     dict, pmt::mp("csi"), pmt::init_c32vector(csi.size(), csi));
 
-                add_item_tag(0,
-                             nitems_written(0) + o,
-                             pmt::string_to_symbol("wifi_start"),
-                             dict,
-                             pmt::string_to_symbol(alias()));
+                pmt::pmt_t pairs = pmt::dict_items(dict);
+                for (int i = 0; i < pmt::length(pairs); i++) {
+                    pmt::pmt_t pair = pmt::nth(i, pairs);
+                    add_item_tag(0,
+                                 nitems_written(0) + o,
+                                 pmt::car(pair),
+                                 pmt::cdr(pair),
+                                 alias_pmt());
+                }
+
             }
         }
 

--- a/lib/frame_equalizer_impl.cc
+++ b/lib/frame_equalizer_impl.cc
@@ -219,14 +219,14 @@ int frame_equalizer_impl::general_work(int noutput_items,
 
                 pmt::pmt_t dict = pmt::make_dict();
                 dict = pmt::dict_add(
-                    dict, pmt::mp("frame_bytes"), pmt::from_uint64(d_frame_bytes));
+                    dict, pmt::mp("frame bytes"), pmt::from_uint64(d_frame_bytes));
                 dict = pmt::dict_add(
                     dict, pmt::mp("encoding"), pmt::from_uint64(d_frame_encoding));
                 dict = pmt::dict_add(
                     dict, pmt::mp("snr"), pmt::from_double(d_equalizer->get_snr()));
-                dict = pmt::dict_add(dict, pmt::mp("nom_freq"), pmt::from_double(d_freq));
+                dict = pmt::dict_add(dict, pmt::mp("nominal frequency"), pmt::from_double(d_freq));
                 dict = pmt::dict_add(dict,
-                                     pmt::mp("freq_offset"),
+                                     pmt::mp("frequency offset"),
                                      pmt::from_double(d_freq_offset_from_synclong));
                 dict = pmt::dict_add(dict, pmt::mp("beta"), pmt::from_double(beta));
 

--- a/lib/parse_mac.cc
+++ b/lib/parse_mac.cc
@@ -71,7 +71,7 @@ public:
             return;
         }
 
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Duration"), pmt::mp(h->duration));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("duration"), pmt::mp(h->duration));
 
 #define HEX(a) std::hex << std::setfill('0') << std::setw(2) << int(a) << std::dec
         dout << "duration: " << HEX(h->duration >> 8) << " " << HEX(h->duration & 0xff)
@@ -82,24 +82,24 @@ public:
         switch ((h->frame_control >> 2) & 3) {
 
         case 0:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Type"), pmt::mp("Management"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("type"), pmt::mp("management"));
             dout << " (MANAGEMENT)" << std::endl;
             parse_management((char*)h, frame_len);
             break;
         case 1:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Type"), pmt::mp("Control"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("type"), pmt::mp("Control"));
             dout << " (CONTROL)" << std::endl;
             parse_control((char*)h, frame_len);
             break;
 
         case 2:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Type"), pmt::mp("Data"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("type"), pmt::mp("Data"));
             dout << " (DATA)" << std::endl;
             parse_data((char*)h, frame_len);
             break;
 
         default:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Type"), pmt::mp("Unknown"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("type"), pmt::mp("Unknown"));
             dout << " (unknown)" << std::endl;
             break;
         }
@@ -130,43 +130,43 @@ public:
         switch (((h->frame_control) >> 4) & 0xf) {
         case 0:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Association Request"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Association Request"));
             dout << "Association Request";
             break;
         case 1:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("Association Response"));
+                d_meta, pmt::mp("subtype"), pmt::mp("Association Response"));
             dout << "Association Response";
             break;
         case 2:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("Reassociation Request"));
+                d_meta, pmt::mp("subtype"), pmt::mp("Reassociation Request"));
             dout << "Reassociation Request";
             break;
         case 3:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("Reassociation Response"));
+                d_meta, pmt::mp("subtype"), pmt::mp("Reassociation Response"));
             dout << "Reassociation Response";
             break;
         case 4:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Probe Request"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Probe Request"));
             dout << "Probe Request";
             break;
         case 5:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Probe Response"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Probe Response"));
             dout << "Probe Response";
             break;
         case 6:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("Timing Advertisement"));
+                d_meta, pmt::mp("subtype"), pmt::mp("Timing Advertisement"));
             dout << "Timing Advertisement";
             break;
         case 7:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Reserved"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Reserved"));
             dout << "Reserved";
             break;
         case 8:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Beacon"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Beacon"));
             dout << "Beacon" << std::endl;
             if (length < 38) {
                 return;
@@ -177,37 +177,37 @@ public:
                     return;
                 }
                 std::string s(buf + 24 + 14, *len);
-                d_meta = pmt::dict_add(d_meta, pmt::mp("SSID"), pmt::mp(s));
+                d_meta = pmt::dict_add(d_meta, pmt::mp("ssid"), pmt::mp(s));
                 dout << "SSID: " << s;
             }
             break;
         case 9:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("ATIM"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("ATIM"));
             dout << "ATIM";
             break;
         case 10:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Disassociation"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Disassociation"));
             dout << "Disassociation";
             break;
         case 11:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Authentication"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Authentication"));
             dout << "Authentication";
             break;
         case 12:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Deauthentication"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Deauthentication"));
             dout << "Deauthentication";
             break;
         case 13:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Action"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Action"));
             dout << "Action";
             break;
         case 14:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Action No Ack"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Action No Ack"));
             dout << "Action No Ack";
             break;
         case 15:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Reserved"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Reserved"));
             dout << "Reserved";
             break;
         default:
@@ -216,19 +216,19 @@ public:
         dout << std::endl;
 
         int seq_no = int(h->seq_nr >> 4);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Sequence number"), pmt::mp(seq_no));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("sequence number"), pmt::mp(seq_no));
         dout << "seq nr: " << seq_no << std::endl;
 
         auto address = format_mac_address(h->addr1);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Address 1"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("address 1"), pmt::mp(address));
         dout << "address 1: " << address << std::endl;
 
         address = format_mac_address(h->addr2);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Address 2"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("address 2"), pmt::mp(address));
         dout << "address 2: " << address << std::endl;
 
         address = format_mac_address(h->addr3);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Address 3"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("address 3"), pmt::mp(address));
         dout << "address 3: " << address << std::endl;
     }
 
@@ -244,73 +244,73 @@ public:
         dout << "Subtype: ";
         switch (((h->frame_control) >> 4) & 0xf) {
         case 0:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Data"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Data"));
             dout << "Data";
             break;
         case 1:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Data + CF-ACK"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Data + CF-ACK"));
             dout << "Data + CF-ACK";
             break;
         case 2:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Data + CR-Poll"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Data + CR-Poll"));
             dout << "Data + CR-Poll";
             break;
         case 3:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("Data + CF-ACK + CF-Poll"));
+                d_meta, pmt::mp("subtype"), pmt::mp("Data + CF-ACK + CF-Poll"));
             dout << "Data + CF-ACK + CF-Poll";
             break;
         case 4:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Null"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Null"));
             dout << "Null";
             break;
         case 5:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("CF-ACK"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("CF-ACK"));
             dout << "CF-ACK";
             break;
         case 6:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("CF-Poll"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("CF-Poll"));
             dout << "CF-Poll";
             break;
         case 7:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("CF-ACK + CF-Poll"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("CF-ACK + CF-Poll"));
             dout << "CF-ACK + CF-Poll";
             break;
         case 8:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("QoS Data"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("QoS Data"));
             dout << "QoS Data";
             break;
         case 9:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("QoS Data + CF-ACK"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("QoS Data + CF-ACK"));
             dout << "QoS Data + CF-ACK";
             break;
         case 10:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("QoS Data + CF-Poll"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("QoS Data + CF-Poll"));
             dout << "QoS Data + CF-Poll";
             break;
         case 11:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("QoS Data + CF-ACK + CF-Poll"));
+                d_meta, pmt::mp("subtype"), pmt::mp("QoS Data + CF-ACK + CF-Poll"));
             dout << "QoS Data + CF-ACK + CF-Poll";
             break;
         case 12:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("QoS Null"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("QoS Null"));
             dout << "QoS Null";
             break;
         case 13:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Reserved"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Reserved"));
             dout << "Reserved";
             break;
         case 14:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("QoS CF-Poll"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("QoS CF-Poll"));
             dout << "QoS CF-Poll";
             break;
         case 15:
             d_meta = pmt::dict_add(
-                d_meta, pmt::mp("Subtype"), pmt::mp("QoS CF-ACK + CF-Poll"));
+                d_meta, pmt::mp("subtype"), pmt::mp("QoS CF-ACK + CF-Poll"));
             dout << "QoS CF-ACK + CF-Poll";
             break;
         default:
@@ -320,31 +320,31 @@ public:
 
 
         int seq_no = int(h->seq_nr >> 4);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Sequence number"), pmt::mp(seq_no));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("sequence number"), pmt::mp(seq_no));
         dout << "seq nr: " << seq_no << std::endl;
 
         auto address = format_mac_address(h->addr1);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Address 1"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("address 1"), pmt::mp(address));
         dout << "address 1: " << address << std::endl;
 
         address = format_mac_address(h->addr2);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Address 2"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("address 2"), pmt::mp(address));
         dout << "address 2: " << address << std::endl;
 
         address = format_mac_address(h->addr3);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Address 3"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("address 3"), pmt::mp(address));
         dout << "address 3: " << address << std::endl;
 
 
         float lost_frames = seq_no - d_last_seq_no - 1;
         if (lost_frames < 0)
             lost_frames += 1 << 12;
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Lost frames"), pmt::mp(lost_frames));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("lost frames"), pmt::mp(lost_frames));
 
         // calculate frame error rate
         float fer = lost_frames / (lost_frames + 1);
         dout << "instantaneous fer: " << fer << std::endl;
-        d_meta = pmt::dict_add(d_meta, pmt::mp("Instantaneous FER"), pmt::mp(fer));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("instantaneous fer"), pmt::mp(fer));
 
         // keep track of sequence numbers
         d_last_seq_no = seq_no;
@@ -358,45 +358,45 @@ public:
         switch (((h->frame_control) >> 4) & 0xf) {
         case 7:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Control Wrapper"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Control Wrapper"));
             dout << "Control Wrapper";
             break;
         case 8:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Block ACK Request"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Block ACK Request"));
             dout << "Block ACK Request";
             break;
         case 9:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Block ACK"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Block ACK"));
             dout << "Block ACK";
             break;
         case 10:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("PS Poll"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("PS Poll"));
             dout << "PS Poll";
             break;
         case 11:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("RTS"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("RTS"));
             dout << "RTS";
             break;
         case 12:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("CTS"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("CTS"));
             dout << "CTS";
             break;
         case 13:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("ACK"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("ACK"));
             dout << "ACK";
             break;
         case 14:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("CF-End"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("CF-End"));
             dout << "CF-End";
             break;
         case 15:
             d_meta =
-                pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("CF-End + CF-ACK"));
+                pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("CF-End + CF-ACK"));
             dout << "CF-End + CF-ACK";
             break;
         default:
-            d_meta = pmt::dict_add(d_meta, pmt::mp("Subtype"), pmt::mp("Reserved"));
+            d_meta = pmt::dict_add(d_meta, pmt::mp("subtype"), pmt::mp("Reserved"));
             dout << "Reserved";
             break;
         }
@@ -404,11 +404,11 @@ public:
 
 
         auto address = format_mac_address(h->addr1);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("RA"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("ra"), pmt::mp(address));
         dout << "RA: " << address << std::endl;
 
         address = format_mac_address(h->addr2);
-        d_meta = pmt::dict_add(d_meta, pmt::mp("TA"), pmt::mp(address));
+        d_meta = pmt::dict_add(d_meta, pmt::mp("ta"), pmt::mp(address));
         dout << "TA: " << address << std::endl;
     }
 


### PR DESCRIPTION
The Frame Equalizer currently propagates metadata as a dictionary stored in a single tag. I suggest we instead propagate each entry as a separate tag, which is more in line with how standard GNU Radio blocks do it (see for example PDU to Tagged Stream block). This is also how the Extract CSI block does it.

Such a modification also removes a lot of unnecessary variables and type conversions (from and to pmt types) in the Decode MAC block.