### PR TITLE
Enable debug on Parse MAC in loopback example.

### DIFF
--- a/examples/wifi_loopback.grc
+++ b/examples/wifi_loopback.grc
@@ -422,8 +422,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    debug: 'False'
-    log: 'True'
+    debug: 'True'
+    log: 'False'
     maxoutbuf: '0'
     minoutbuf: '0'
   states:


### PR DESCRIPTION
The readme says that if you run the loopback example, then "If everything works as intended you should see some decoded packets on the console". For this to be true out of the box, the debug option on the Parse MAC block must be enabled.