### PR TITLE
Fix `format_mac_address` function in parse_mac.cc

### DIFF
--- a/lib/parse_mac.cc
+++ b/lib/parse_mac.cc
@@ -419,7 +419,7 @@ public:
         str << std::setfill('0') << std::hex << std::setw(2) << (int)addr[0];
 
         for (int i = 1; i < 6; i++) {
-            str << ":" << (int)addr[i];
+            str << ":" << std::setw(2) << (int)addr[i];
         }
 
         return str.str();


### PR DESCRIPTION
Apparently the stream manipulator `std::setw` applies only to the next string written to the stream. Hence the function `format_mac_address` in parse_mac.cc only formatted the first pair of hexadecimal digits correctly. This went unnoticed until now because it only makes a difference for numbers below 0x10.