### PR TITLE
fix CMake pybind11 configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,16 @@ if(APPLE)
 endif(APPLE)
 
 ########################################################################
+# PyBind11 Related
+########################################################################
+
+find_package(pybind11 REQUIRED)
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c
+    "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
+    OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR)
+
+########################################################################
 # Find gnuradio build dependencies
 ########################################################################
 find_package(Doxygen)


### PR DESCRIPTION
Hi,
this PR is adding few extra lines in CMakeLists.txt to load the pybind11 related code and build maint-3.9 with gnuradio 3.9.

Cheers,
Luca