### PR TITLE
add missing include boost/format.hpp

### DIFF
--- a/lib/decode_mac.cc
+++ b/lib/decode_mac.cc
@@ -21,6 +21,7 @@
 
 #include <gnuradio/io_signature.h>
 #include <boost/crc.hpp>
+#include <boost/format.hpp> 
 #include <iomanip>
 
 using namespace gr::ieee802_11;

--- a/lib/frame_equalizer_impl.cc
+++ b/lib/frame_equalizer_impl.cc
@@ -23,6 +23,7 @@
 #include "frame_equalizer_impl.h"
 #include "utils.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp> 
 
 namespace gr {
 namespace ieee802_11 {

--- a/lib/parse_mac.cc
+++ b/lib/parse_mac.cc
@@ -20,6 +20,7 @@
 #include <gnuradio/block_detail.h>
 #include <gnuradio/io_signature.h>
 #include <string>
+#include <boost/format.hpp> 
 
 using namespace gr::ieee802_11;
 

--- a/lib/sync_long.cc
+++ b/lib/sync_long.cc
@@ -23,6 +23,7 @@
 
 #include <list>
 #include <tuple>
+#include <boost/format.hpp> 
 
 using namespace gr::ieee802_11;
 using namespace std;

--- a/lib/sync_short.cc
+++ b/lib/sync_short.cc
@@ -19,6 +19,7 @@
 #include <ieee802_11/sync_short.h>
 
 #include <iostream>
+#include <boost/format.hpp> 
 
 using namespace gr::ieee802_11;
 


### PR DESCRIPTION
This is needed for boost 1.71 and GNU Radio 3.11