### PR TITLE
Fix for insufficient initialization for generic decoder.

### DIFF
--- a/lib/viterbi_decoder/viterbi_decoder_generic.cc
+++ b/lib/viterbi_decoder/viterbi_decoder_generic.cc
@@ -414,7 +414,7 @@ void viterbi_decoder::viterbi_chunks_init_generic()
 {
     int i, j;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 64; i++) {
         d_metric0_generic[i] = 0;
         d_path0_generic[i] = 0;
     }


### PR DESCRIPTION
On x86 SSE environment,  viterbi_decoder_x86.cc is used and has no issue,
But on generic environment, viterbi_decoder_generic.cc is used and has an issue.

In the SSE environment, d_metric0 is 4 count array of  __m128i.
` __m128i d_metric0[4] __attribute__((aligned(16)));`

but in the generic environment, d_metric0_generic is 64 count array of unsigned char.
`unsigned char d_metric0_generic[64] __attribute__((aligned(16)));`

So the  metric is insufficiently initialized in the generic environment after 2nd frame.
