### PR TITLE
Add support for gnuradio 3.11 / newer spdlog library

### DIFF
--- a/lib/decode_mac.cc
+++ b/lib/decode_mac.cc
@@ -147,8 +147,8 @@ public:
             return;
         }
 
-        mylog(boost::format("encoding: %1% - length: %2% - symbols: %3%") %
-              d_ofdm.encoding % d_frame.psdu_size % d_frame.n_sym);
+        d_logger->info("encoding: {} - length: {} - symbols: {}",
+              d_ofdm.encoding, d_frame.psdu_size, d_frame.n_sym);
 
         // create PDU
         pmt::pmt_t blob = pmt::make_blob(out_bytes + 2, d_frame.psdu_size - 4);

--- a/lib/frame_equalizer_impl.cc
+++ b/lib/frame_equalizer_impl.cc
@@ -360,8 +360,8 @@ bool frame_equalizer_impl::parse_signal(uint8_t* decoded_bits)
         return false;
     }
 
-    mylog(boost::format("encoding: %1% - length: %2% - symbols: %3%") % d_frame_encoding %
-          d_frame_bytes % d_frame_symbols);
+    d_logger->info("encoding: {} - length: {} - symbols: {}",d_frame_encoding,
+          d_frame_bytes, d_frame_symbols);
     return true;
 }
 

--- a/lib/parse_mac.cc
+++ b/lib/parse_mac.cc
@@ -64,7 +64,7 @@ public:
         int frame_len = pmt::blob_length(d_msg);
         mac_header* h = (mac_header*)pmt::blob_data(d_msg);
 
-        mylog(boost::format("length: %1%") % frame_len);
+        d_logger->info("length: {}",frame_len);
 
         dout << std::endl << "new mac frame  (length " << frame_len << ")" << std::endl;
         dout << "=========================================" << std::endl;

--- a/lib/sync_long.cc
+++ b/lib/sync_long.cc
@@ -113,7 +113,7 @@ public:
 
                 if (d_offset == SYNC_LENGTH) {
                     search_frame_start();
-                    mylog(boost::format("LONG: frame start at %1%") % d_frame_start);
+                    d_logger->info("LONG: frame start at {}",d_frame_start);
                     d_offset = 0;
                     d_count = 0;
                     d_state = COPY;

--- a/lib/sync_short.cc
+++ b/lib/sync_short.cc
@@ -139,7 +139,7 @@ public:
 
     void insert_tag(uint64_t item, double freq_offset, uint64_t input_item)
     {
-        mylog(boost::format("frame start at in: %2% out: %1%") % item % input_item);
+        d_logger->info("frame start at in: {} out: {}", item, input_item);
 
         const pmt::pmt_t key = pmt::string_to_symbol("wifi_start");
         const pmt::pmt_t value = pmt::from_double(freq_offset);

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -34,7 +34,9 @@ using gr::ieee802_11::Encoding;
 #define mylog(msg)                      \
     do {                                \
         if (d_log) {                    \
-            GR_LOG_INFO(d_logger, msg); \
+            std::ostringstream msgx;    \
+            msgx << msg;                \
+            GR_LOG_INFO(d_logger, msgx.str()); \
         }                               \
     } while (0);
 

--- a/lib/viterbi_decoder/viterbi_decoder_generic.cc
+++ b/lib/viterbi_decoder/viterbi_decoder_generic.cc
@@ -414,7 +414,7 @@ void viterbi_decoder::viterbi_chunks_init_generic()
 {
     int i, j;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 64; i++) {
         d_metric0_generic[i] = 0;
         d_path0_generic[i] = 0;
     }


### PR DESCRIPTION
This fixes issues with spdlog on newer ubuntu (updated gnuradio format specification) and latest gnuradio version 3.11. Tested with ubuntu 23.04. See: https://wiki.gnuradio.org/index.php/Logging#Logging_in_C++