### PR TITLE
Add YAML manifest, add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,3 +161,7 @@ endif(ENABLE_PYTHON)
 install(FILES cmake/Modules/ieee802_11Config.cmake
     DESTINATION ${CMAKE_MODULES_DIR}/ieee802_11
 )
+
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/ieee802_11)

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,23 @@
+title: The IEEE801_11 OOT Module
+version: 1.0
+brief: IEEE 802.11 a/g/p Transceiver
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - IEEE 802.11
+  - WiFi
+  - OFDM
+author:
+  - Bastian Bloessl <bloessl@ccs-labs.org>
+copyright_owner:
+  - Bastian Bloessl
+license: GPL-3.0-or-later
+gr_supported_version:
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+repo: https://github.com/bastibl/gr-ieee802-11.git
+website: http://www.ccs-labs.org/projects/wime/
+icon: http://www.ccs-labs.org/projects/wime/wime.png
+description: |-
+  This an IEEE 802.11 a/g/p transceiver for GNU Radio. Over the air, I tested it with the Ettus USRP N210 with XCVR2450 and CBX daughterboards. For interoperability tests I use mainly an Atheros (ath5k) WiFi card. The code can also be used for packet error rate simulations.
+file_format: 1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,4 +11,4 @@ install(
           wifi_rx.grc
           wifi_transceiver.grc
           wifi_tx.grc
-    DESTINATION ${GR_PKG_DATA_DIR}/examples)
+    DESTINATION share/gnuradio/examples/ieee802_11)


### PR DESCRIPTION
1. YAML manifest is installed and will be used by GRC-Qt for its OOT module browser
2. Install examples to directory that is discoverable by GRC-Qt example browser
3. Force checkouts on Windows to use Unix-style line endings so that the Python binding header hash check does not fail