### PR TITLE
Fix: Corrected typo 'defaut' to 'default' in switch statements

### DIFF
--- a/lib/utils.cc
+++ b/lib/utils.cc
@@ -89,7 +89,7 @@ ofdm_param::ofdm_param(Encoding e)
         n_dbps = 216;
         rate_field = 0x03; // 0b00000011
         break;
-    defaut:
+    default:
         assert(false);
         break;
     }
@@ -211,7 +211,7 @@ void puncturing(const char* in, char* out, frame_param& frame, ofdm_param& ofdm)
                 out++;
             }
             break;
-        defaut:
+        default:
             assert(false);
             break;
         }


### PR DESCRIPTION
This PR fixes a typo in the utils.cc file where the 'defaut' keyword was misspelled instead of the correct 'default' in several switch blocks.